### PR TITLE
CB:MoveObject rotation params fix

### DIFF
--- a/cb/cbList.inc
+++ b/cb/cbList.inc
@@ -2717,7 +2717,7 @@ CB:MoveObject(playerid, blockid, world, params[])
 		Float:speed;
 	
 	ReturnCommand(playerid, params, world);
-	if(sscanf(params, "dfffF(0.0)F(0.0)F(0.0)F(0.0)", objectid, x, y, z, speed, rx, rz, ry))
+	if(sscanf(params, "dfffF(0.0)F(0.0)F(0.0)F(0.0)", objectid, x, y, z, speed, rx, ry, rz))
 		return CBWrongData(playerid, blockid, world);
 	
 	if(speed < 0.0 || speed > 50.0)


### PR DESCRIPTION
Перепутаны местами углы поворота у `CB:MoveObject`

- В описании функции четко обозначен порядок: rx ry rz
- В установке поворота тоже стоит порядок `SetDynamicObjectRot(objectid, rx, ry, rz)`
- В sscanf порядок перепутан `sscanf(params, "dfffF(0.0)F(0.0)F(0.0)F(0.0)", objectid, x, y, z, speed, rx, rz, ry)`

Фикс может вызвать проблемы у тех, кто уже использовал данную функцию с установленными ry и rz (и нагло умолчал баг). Но это не самые часто используемые параметры, так что проблемы будут небольшие